### PR TITLE
Fix redirect to login page

### DIFF
--- a/Classes/Domain/Repository/PageRepository.php
+++ b/Classes/Domain/Repository/PageRepository.php
@@ -79,7 +79,7 @@ class PageRepository implements \TYPO3\CMS\Core\SingletonInterface
             foreach ($rows as $row) {
                 foreach ($rootLine as $pageRecord) {
                     if ((int) $pageRecord['uid'] === (int) $row['pid']) {
-                        return $this->findByIdentifier($rows['pid']);
+                        return $this->findByIdentifier($row['pid']);
                     }
                 }
             }


### PR DESCRIPTION
User correct variable name to check for pid.
Keys in $rows array are not PID's, but a counter of records returned from DB.

var_export($rows) returns:
```
 array (
  0 => 
  array (
    'pid' => '19',
  ),
) 
```